### PR TITLE
Fix duplicated check

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -123,6 +123,8 @@ public class Person {
         }
 
         boolean isExactMatch = otherPerson.getName().equals(getName());
+        boolean isSamePhone = otherPerson.getPhone().equals(getPhone());
+        boolean isSameEmail = otherPerson.getEmail().equals(getEmail());
 
         // Check for similarity by comparing alphanumeric characters
         boolean nameSimilar = stripNonAlphanumeric(name.toString())
@@ -137,7 +139,7 @@ public class Person {
         boolean tagsSimilar = tags.equals(otherPerson.getTags());
 
         if (!isExactMatch) {
-            if (emailSimilar || phoneSimilar) {
+            if (isSameEmail || isSamePhone || emailSimilar || phoneSimilar) {
                 return new PersonSimilarity(false, true);
             } else if (nameSimilar) {
                 return new PersonSimilarity(false, true);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -136,20 +136,30 @@ public class Person {
         boolean gradesSimilar = Arrays.equals(grades, otherPerson.getGrades());
         boolean tagsSimilar = tags.equals(otherPerson.getTags());
 
-        boolean isLikelySame = nameSimilar && emailSimilar && phoneSimilar && addressSimilar
-                && gradesSimilar && tagsSimilar;
-        boolean isOtherFieldfifferent = !emailSimilar || !phoneSimilar || !addressSimilar
-                || !gradesSimilar || !tagsSimilar;
+        if (!isExactMatch) {
+            if (emailSimilar || phoneSimilar) {
+                return new PersonSimilarity(false, true);
+            } else if (nameSimilar) {
+                return new PersonSimilarity(false, true);
+            } else {
+                return new PersonSimilarity(false, false);
+            }
+        }
+//        boolean isLikelySame = nameSimilar && emailSimilar && phoneSimilar && addressSimilar
+//                && gradesSimilar && tagsSimilar;
+
+        boolean isOtherFieldfifferent = !addressSimilar
+                || !gradesSimilar || !tagsSimilar || !phoneSimilar || !emailSimilar;
         if (isExactMatch) {
             if (isOtherFieldfifferent) {
                 return new PersonSimilarity(false, true);
             }
             return new PersonSimilarity(true, false);
         }
-
-        if (isLikelySame) {
-            return new PersonSimilarity(false, true);
-        }
+//
+//        if (isLikelySame) {
+//            return new PersonSimilarity(false, true);
+//        }
         return new PersonSimilarity(false, false);
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -145,8 +145,6 @@ public class Person {
                 return new PersonSimilarity(false, false);
             }
         }
-//        boolean isLikelySame = nameSimilar && emailSimilar && phoneSimilar && addressSimilar
-//                && gradesSimilar && tagsSimilar;
 
         boolean isOtherFieldfifferent = !addressSimilar
                 || !gradesSimilar || !tagsSimilar || !phoneSimilar || !emailSimilar;
@@ -156,10 +154,6 @@ public class Person {
             }
             return new PersonSimilarity(true, false);
         }
-//
-//        if (isLikelySame) {
-//            return new PersonSimilarity(false, true);
-//        }
         return new PersonSimilarity(false, false);
     }
 

--- a/src/test/java/seedu/address/logic/commands/GroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GroupCommandTest.java
@@ -26,10 +26,14 @@ public class GroupCommandTest {
     @Test
     public void execute_groupCommand_groupsStudents() {
         // Create sample students
-        Person student1 = new PersonBuilder().withName("Alice").withGrade(PersonBuilder.DEFAULT_GRADES).build();
-        Person student2 = new PersonBuilder().withName("Bob").withGrade(PersonBuilder.F_GRADES).build();
-        Person student3 = new PersonBuilder().withName("Charlie").withGrade(PersonBuilder.DEFAULT_GRADES).build();
-        Person student4 = new PersonBuilder().withName("David").withGrade(PersonBuilder.A_GRADES).build();
+        Person student1 = new PersonBuilder().withName("Alice").withPhone("12345678").withEmail("Alice@gmail.com")
+                .withGrade(PersonBuilder.DEFAULT_GRADES).build();
+        Person student2 = new PersonBuilder().withName("Bob").withPhone("12345670").withEmail("bob@gmail.com")
+                .withGrade(PersonBuilder.F_GRADES).build();
+        Person student3 = new PersonBuilder().withName("Charlie").withPhone("12345078").withEmail("Char@gmail.com")
+                .withGrade(PersonBuilder.DEFAULT_GRADES).build();
+        Person student4 = new PersonBuilder().withName("David").withPhone("12045678").withEmail("David@gmail.com")
+                .withGrade(PersonBuilder.A_GRADES).build();
 
         model.addPerson(student1);
         model.addPerson(student2);

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -106,6 +106,15 @@ public class PersonTest {
         assertFalse(result.isSame);
         assertTrue(result.isLikelySame);
 
+        // same phone but different name and email -> returns false and true for likely same
+        editedAlice = new PersonBuilder(ALICE)
+                .withName("Different Name")
+                .withEmail("different@email.com")
+                .withPhone(ALICE.getPhone().toString())
+                .build();
+        result = ALICE.isSamePerson(editedAlice);
+        assertFalse(result.isSame);
+        assertTrue(result.isLikelySame);
         // same email but different name and phone -> returns false and true for likely same
         editedAlice = new PersonBuilder(ALICE)
                 .withName("Different Name")
@@ -119,6 +128,24 @@ public class PersonTest {
         // similar name with special characters -> returns false and true for likely same
         editedAlice = new PersonBuilder(ALICE)
                 .withName("Alices/oPauline123")
+                .build();
+        result = ALICE.isSamePerson(editedAlice);
+        assertFalse(result.isSame);
+        assertTrue(result.isLikelySame);
+
+        // same fields but with different case and spacing -> returns false and true for likely same
+        editedAlice = new PersonBuilder(ALICE)
+                .withEmail("ALICE@EXAMPLE.COM")
+                .withPhone("94351253")
+                .build();
+        result = ALICE.isSamePerson(editedAlice);
+        assertTrue(result.isSame);
+        assertFalse(result.isLikelySame);
+        // different name with simlar fields -> returns false and true for likely same
+        editedAlice = new PersonBuilder(ALICE)
+                .withName("BOB")
+                .withEmail("ALICE@EXAMPLE.COM")
+                .withPhone("94351253")
                 .build();
         result = ALICE.isSamePerson(editedAlice);
         assertFalse(result.isSame);

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -84,6 +84,45 @@ public class PersonTest {
         result = BOB.isSamePerson(editedBob);
         assertFalse(result.isSame);
         assertTrue(result.isLikelySame);
+
+        // similar name (case difference) but all other fields different -> returns false and true for likely same
+        editedAlice = new PersonBuilder(ALICE)
+                .withName(ALICE.getName().toString().toUpperCase())
+                .withPhone("99999999")
+                .withEmail("different@email.com")
+                .withAddress("Different Address")
+                .build();
+        result = ALICE.isSamePerson(editedAlice);
+        assertFalse(result.isSame);
+        assertTrue(result.isLikelySame);
+
+        // same email but different name and phone -> returns false and true for likely same
+        editedAlice = new PersonBuilder(ALICE)
+                .withName("Different Name")
+                .withPhone("99999999")
+                .withEmail(ALICE.getEmail().toString())
+                .build();
+        result = ALICE.isSamePerson(editedAlice);
+        assertFalse(result.isSame);
+        assertTrue(result.isLikelySame);
+
+        // same email but different name and phone -> returns false and true for likely same
+        editedAlice = new PersonBuilder(ALICE)
+                .withName("Different Name")
+                .withPhone("99999999")
+                .withEmail(ALICE.getEmail().toString())
+                .build();
+        result = ALICE.isSamePerson(editedAlice);
+        assertFalse(result.isSame);
+        assertTrue(result.isLikelySame);
+
+        // similar name with special characters -> returns false and true for likely same
+        editedAlice = new PersonBuilder(ALICE)
+                .withName("Alices/oPauline123")
+                .build();
+        result = ALICE.isSamePerson(editedAlice);
+        assertFalse(result.isSame);
+        assertTrue(result.isLikelySame);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -51,14 +51,16 @@ public class PersonTest {
         assertTrue(result.isSame);
         assertFalse(result.isLikelySame);
 
-        // different name, but similar (without spaces) -> returns false but likely same
-        editedAlice = new PersonBuilder(ALICE).withName("AlicePauline").build();
+        // similar name and email but same phonenumber -> returns true with no likely similarity
+        editedAlice = new PersonBuilder(ALICE).withName("AlicePauline").withEmail("aliCE@example.com")
+                .withPhone("94351253").build();
         result = ALICE.isSamePerson(editedAlice);
         assertFalse(result.isSame);
         assertTrue(result.isLikelySame);
 
         // different name, but similar (part of uppercase) -> returns false but likely same
-        editedAlice = new PersonBuilder(ALICE).withName("ALICE Pauline").build();
+        editedAlice = new PersonBuilder(ALICE).withName("Pauline").withEmail("alice@example.com").withPhone("94351253")
+                .build();
         result = ALICE.isSamePerson(editedAlice);
         assertFalse(result.isSame);
         assertTrue(result.isLikelySame);
@@ -69,14 +71,14 @@ public class PersonTest {
         assertFalse(result.isSame);
         assertTrue(result.isLikelySame);
 
-        // similar email but different name -> returns false due to compeltely different name
+        // similar email but different name -> returns false but likely same
         editedAlice = new PersonBuilder(ALICE).withName("Different Name")
                 .withEmail("alice@example.com").build();
         result = ALICE.isSamePerson(editedAlice);
         assertFalse(result.isSame);
-        assertFalse(result.isLikelySame);
+        assertTrue(result.isLikelySame);
 
-        // same name  but different email -> returns false but similar
+        // same name but different email -> returns false but similar
         editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB)
                 .withEmail("alice@example.com").build();
         result = BOB.isSamePerson(editedBob);


### PR DESCRIPTION
i think is more reasonable that if they  are not exactly same name, we check for email and phone and if one of them are same we give warning for similar person, then check if they have similar name , otherwise they are confirm different person
(if not person with completely different name and same phone will be identified as same person which is weird)

when they have exactly same name, check if other field including phone and email are different, is the other field are different we still give similar person warning.

Fix #183 